### PR TITLE
Migrate to tsd from dtslint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [8, 10, 12, 16, 18, 20, 21]
+        node-version: [16, 18, 20, 21]
 
     steps:
       - name: Clone repository

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,6 @@ jobs:
     strategy:
       matrix:
         node-version: [16, 18, 20, 21]
-        typescript-version: ["3.x", "4.x", "5.x"]
 
     steps:
       - name: Clone repository
@@ -26,9 +25,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: "${{ matrix.node-version }}"
-
-      - name: Set up Typescript
-        run: npm install typescript@${{ matrix.typescript-version }}
 
       - name: Install npm dependencies
         run: npm install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,9 @@ env:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [8, 10, 12, 16, 18, 20, 21]
 
     steps:
       - name: Clone repository
@@ -21,7 +24,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: "${{ matrix.node-version }}"
 
       - name: Install npm dependencies
         run: npm install
@@ -29,5 +32,5 @@ jobs:
       - name: Run lint
         run: npm run lint
 
-      - name: Run dtslint
-        run: npm run dtslint
+      - name: Run tsd
+        run: npm run tsd

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         node-version: [16, 18, 20, 21]
+        typescript-version: ["3.x", "4.x", "5.x"]
 
     steps:
       - name: Clone repository
@@ -26,11 +27,14 @@ jobs:
         with:
           node-version: "${{ matrix.node-version }}"
 
+      - name: Set up Typescript
+        run: npm install typescript@${{ matrix.typescript-version }}
+
       - name: Install npm dependencies
         run: npm install
 
       - name: Run lint
         run: npm run lint
 
-      - name: Run tsd
+      - name: type-check
         run: npm run tsd

--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
   "devDependencies": {
     "@types/node": "^14",
     "chai": "^4.3",
-    "dtslint": "^3.3.0",
     "eslint": "^7.0.0",
     "mocha": "^7.0.0",
     "rimraf": "^3.0.0",
     "sinon": "^9.0.1",
     "sinon-chai": "^3.3.0",
+    "tsd": "^0.30.4",
     "typescript": "^4.4.3",
     "upath": "^1.2.0"
   },
@@ -51,7 +51,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "dtslint": "dtslint types",
+    "tsd": "tsd",
     "lint": "eslint --report-unused-disable-directives --ignore-path .gitignore .",
     "build": "npm ls",
     "mocha": "mocha --exit --timeout 90000",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,3 @@
-// TypeScript Version: 3.0
-
 /// <reference types="node" />
 
 import * as fs from "fs";

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs";
-import chokidar from "chokidar";
+import chokidar from "../";
 
 const watcher = chokidar.watch("file, dir, or glob", {
   ignored: /[\/\\]\./,
@@ -7,7 +7,6 @@ const watcher = chokidar.watch("file, dir, or glob", {
 });
 
 const log = console.log.bind(console);
-
 watcher
   .add('./foo.js')
   .unwatch('./bar.js')


### PR DESCRIPTION
[Apparently, dtslint no longer works](https://github.com/microsoft/DefinitelyTyped-tools/issues/775) outside of the DefinitelyTyped monorepo. [It's not clear if they have a plan](https://github.com/microsoft/DefinitelyTyped-tools/issues/850) to remedy this, so I've migrated to [tsd](https://github.com/tsdjs/tsd) which is a recommended replacement. 

The one downside to tsd is the inability to [test against multiple typescript versions](https://github.com/tsdjs/tsd/issues/47).